### PR TITLE
include URL of Replicate model

### DIFF
--- a/server/api/prediction.post.ts
+++ b/server/api/prediction.post.ts
@@ -8,6 +8,7 @@ export default defineEventHandler(async (event) => {
   const body = await readBody(event)
   const { ws_key, input } = body
 
+  // https://replicate.com/stability-ai/stable-diffusion-inpainting
   const prediction = await replicate.predictions.create({
     version: 'c28b92a7ecd66eee4aefcd8a94eb9e7f6c3805d5f06038165407fb5cb355ba67',
     input,


### PR DESCRIPTION
When you're looking at this code and all you see is a model version string, there's no way to know what that model actually is. 

Hopefully someday we'll support version strings like `stability-ai/stable-diffusion-inpainting:c28b92a7` for this API endpoint, but for now we can work around it by adding a code comment with the Replicate model URL

