### PR TITLE
bigger prompt input, downplayed upload button

### DIFF
--- a/components/Outpainter.vue
+++ b/components/Outpainter.vue
@@ -13,7 +13,7 @@
     )
     
   .prompt-input.my-5(
-    class="max-w-[512px]"
+    class="w-full"
   )
     input.block.w-full.flex-grow.rounded-l-md.p-3.border.border-gray-300.text-center(
       v-model="prompt"
@@ -22,7 +22,7 @@
       placeholder="Enter a text prompt"
       type="text"
     )
-    button.text-white.bg-gray-900.font-medium.rounded-r-md.text-sm.w-full.px-5.py-3.text-center(
+    button.text-white.bg-gray-900.font-medium.rounded-r-md.text-sm.px-5.py-3.text-center(
       @click="doCreatePrediction"
       :disabled="state === 'loading'"
       class="sm:w-auto"

--- a/components/SelectFile.vue
+++ b/components/SelectFile.vue
@@ -6,11 +6,11 @@
     ref="file"
     accept="image/*"
   )
-  button.mb-4.text-white.bg-gray-400.font-medium.rounded-md.text-sm.w-full.px-5.py-3.text-center(
+  button.mb-4.text-gray-400.border.border-gray-400.font-medium.rounded.text-sm.w-full.px-3.py-2.text-center(
     @click="onSelectFile"
     class="sm:w-auto"
     type="submit"
-  ) Upload an image
+  ) Upload a new starting image
 </template>
 
 <script>


### PR DESCRIPTION
This is an attempt to improve the UI a bit by making the prompt text input wider, so longer prompts don't get visually cut off. I've also tweaked the styles on the upload button, so it's still identifiable as a button but less pronounced than before.

@Pwntus @replicate/dx what do you think?

## Before

<img width="961" alt="Screenshot 2023-06-25 at 4 18 48 PM" src="https://github.com/replicate/outpainter/assets/2289/f98be20d-5bd5-40a6-9fec-840d2eaa010d">

## After

<img width="806" alt="Screenshot 2023-06-25 at 4 18 14 PM" src="https://github.com/replicate/outpainter/assets/2289/9dc0ea51-7e1d-4b55-a4ef-1de080b6b804">


